### PR TITLE
chore(config): replace Infura with Alchemy and POKT public endpoints

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -186,7 +186,7 @@ Create a `.env.local` file with the following variables:
 
 ```plaintext
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=your_wallet_connect_project_id
-NEXT_PUBLIC_INFURA_ID=your_infura_id
+NEXT_PUBLIC_ALCHEMY_ID=your_alchemy_api_key
 ```
 
 4. Run the development server:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cookie-jar-v3",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "private": true,
     "scripts": {
         "dev": "next dev",


### PR DESCRIPTION
BREAKING CHANGE: Removes all Infura usage in favor of Alchemy and POKT endpoints. Updates env var to NEXT_PUBLIC_ALCHEMY_ID. Updates documentation. Bumps version to 2.0.0.

(solves https://github.com/Cookie-Jar-DAO/cookie-jar-v3/issues/175)